### PR TITLE
TST: add travis configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# vim ft=yaml
+# travis-ci.org definition for nipy build
+#
+# We pretend to be erlang because we need can't use the python support in
+# travis-ci; it uses virtualenvs, they do not have numpy, scipy, matplotlib,
+# and it is impractical to build them
+language: erlang
+env:
+    # Enable python 2 and python 3 builds. Python3 available in Ubuntu 12.04.
+    - PYTHON=python PYSUF=''
+install:
+    - sudo apt-get update
+    - sudo apt-get install $PYTHON-dev
+    - sudo apt-get install $PYTHON-numpy
+    - sudo apt-get install $PYTHON-scipy
+    - sudo apt-get install $PYTHON-setuptools
+    - sudo apt-get install $PYTHON-nose
+    - sudo apt-get install $PYTHON-matplotlib
+    - sudo easy_install$PYSUF nibabel # Latest pypi
+    # Cython easy_install breaks with error about refnanny.c; maybe something
+    # to do with having a previous cython version;
+    # http://mail.python.org/pipermail//cython-devel/2012-April/002344.html
+    - curl -O http://www.cython.org/release/Cython-0.18.zip
+    - unzip Cython-0.18.zip
+    - cd Cython-0.18
+    - sudo python$PYSUF setup.py install
+    # Temporary solution to travis issue #155
+    # https://github.com/travis-ci/travis-cookbooks/issues/155
+    - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
+    - cd ..
+    - $PYTHON setup.py build
+    - sudo $PYTHON setup.py install
+script:
+    # Change into an innocuous directory and find tests from installation
+    - mkdir for_test
+    - cd for_test
+       cp ../.coveragerc . ;
+        nosetests$PYSUF --with-doctest --with-coverage `$PYTHON -c "import os; import dipy; print(os.path.dirname(dipy.__file__))"` ;
+      fi


### PR DESCRIPTION
Here's something neat. If you add this file into the repo, and hook up Travis-CI (through "settings" => "webhooks and services". Then - whenever we push into github, it will go and download popeye, and run the test suite on a remote machine. See https://travis-ci.org/nipy/dipy for an example of how that works. That way, every push is monitored, and you get immediate feedback on whether or not things are working. Very useful, once the tests are working.
