### PR TITLE
FIX: travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
     - sudo $PYTHON setup.py install
 script:
     # Change into an innocuous directory and find tests from installation
-    - nosetests$PYSUF --with-doctest --with-coverage --cover-package=popeye
-    #- mkdir for_test
-    #- cd for_test
-    #   cp ../.coveragerc . ;
-    #    nosetests$PYSUF --with-doctest --with-coverage --cover-package=popeye `$PYTHON -c "import os; import popeye; print(os.path.dirname(popeye.__file__))"` ;
+    #- nosetests$PYSUF --with-doctest --with-coverage --cover-package=popeye
+    - mkdir for_test
+    - cd for_test
+       cp ../.coveragerc . ;
+        nosetests$PYSUF --with-doctest --with-coverage --cover-package=popeye `$PYTHON -c "import os; import popeye; print(os.path.dirname(popeye.__file__))"` ;


### PR DESCRIPTION
a recent commit to sharedmem (https://github.com/sturlamolden/sharedmem-numpy/commit/2de37262c4a9018de320835d5041ed2b9abe8504) broke the installation and caused travis to fail. This PR removes sharedmem from travis - it's no longer needed anyway - and should fix the build error.
