### PR TITLE
Round resampled stimulus dimensions

### DIFF
--- a/popeye/visual_stimulus.py
+++ b/popeye/visual_stimulus.py
@@ -104,7 +104,9 @@ def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'
     """
     
     dims = np.shape(stim_arr)
-    resampled_arr = np.zeros((np.int(dims[0]*scale_factor), np.int(dims[1]*scale_factor), dims[2]),dtype=dtype)
+    resampled_arr = np.zeros((np.int(np.round(dims[0] * scale_factor)),
+                              np.int(np.round(dims[1] * scale_factor)),
+                              dims[2]), dtype=dtype)
     
     # loop
     for tr in np.arange(dims[-1]):


### PR DESCRIPTION
Prior code was failing because the size of the initialized `resampled_arr` array was off by one from what `scipy.ndimage.zoom` returns for some combinations of array sizes/scale factors.

Rounding prior to int conversion is what `scipy.ndimage.zoom` [does](https://github.com/scipy/scipy/blob/v0.15.1/scipy/ndimage/interpolation.py#L541) as of scipy 0.13. I am not sure what your minimum scipy version is, but I can add a a line that handles older scipy (though 0.13 is [pretty old](https://docs.scipy.org/doc/scipy-0.13.0/reference/)!)