### PR TITLE
Round using Python function when resampling stimulus array

### DIFF
--- a/popeye/visual_stimulus.py
+++ b/popeye/visual_stimulus.py
@@ -104,8 +104,8 @@ def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'
     """
     
     dims = np.shape(stim_arr)
-    resampled_arr = np.zeros((np.int(np.round(dims[0] * scale_factor)),
-                              np.int(np.round(dims[1] * scale_factor)),
+    resampled_arr = np.zeros((int(round(dims[0] * scale_factor)),
+                              int(round(dims[1] * scale_factor)),
                               dims[2]), dtype=dtype)
     
     # loop


### PR DESCRIPTION
Following up on GH #49

Apparently `scipy.ndimage.zoom` uses the builtin `round()` function, not
`numpy.round()`, to determine the size of the zoomed array.

More surprisingly, those two functions handle .5 differently.

This commit changes popeye to be even more strictly consistent with
`scipy.ndimage.zoom` and fixes an edge case for stimulus array size /
resampling factor.