### PR TITLE
Expose order parameter of scipy.ndimage.zoom in resample_stimulus

### DIFF
--- a/popeye/tests/test_css.py
+++ b/popeye/tests/test_css.py
@@ -73,7 +73,9 @@ def test_css_fit():
     fit = css.CompressiveSpatialSummationFit(model, data, grids, bounds, Ns=Ns)
     
     # coarse fit
-    npt.assert_almost_equal((fit.x0,fit.y0,fit.s0,fit.n0,fit.beta0,fit.baseline0),[-3., 2.,  0.72833938, 0.5,1., -0.02902576])
+    observed = [fit.x0, fit.y0, fit.s0, fit.n0, fit.beta0, fit.baseline0]
+    expected = [-3., 2., 0.72833938, 0.5, 1., -0.02525]
+    npt.assert_almost_equal(observed, expected)
     
     # fine fit
     npt.assert_almost_equal(fit.x, x, 1)

--- a/popeye/tests/test_stimulus.py
+++ b/popeye/tests/test_stimulus.py
@@ -10,6 +10,7 @@ import nose.tools as nt
 
 from popeye.visual_stimulus import pixels_per_degree, generate_coordinate_matrices, resample_stimulus, simulate_sinflicker_bar, simulate_bar_stimulus, VisualStimulus
 
+
 def test_pixels_per_degree():
     
     pixels_across = 1
@@ -104,6 +105,12 @@ def test_resample_stimulus():
     nt.assert_true(stim_coarse_dims[0]/stim_dims[0] == scale_factor)
     nt.assert_true(stim_coarse_dims[1]/stim_dims[1] == scale_factor)
     nt.assert_true(stim_coarse_dims[2] == stim_dims[2])
+
+    # test nearest neighbor interpolation
+    binary_stimulus = (stimulus > .5).astype(np.float)
+    binary_stimulus_coarse = resample_stimulus(binary_stimulus, scale_factor,
+                                               order=0, dtype=np.float)
+    npt.assert_array_equal(np.unique(binary_stimulus_coarse), [0, 1])
 
 def test_simulate_sinflicker_bar():
     

--- a/popeye/visual_stimulus.py
+++ b/popeye/visual_stimulus.py
@@ -70,7 +70,8 @@ def generate_coordinate_matrices(pixels_across, pixels_down, ppd, scale_factor=1
     
     return deg_x, np.flipud(deg_y)
 
-def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'):
+def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest',
+                      order=0, dtype='uint8'):
     
     """Resamples the visual stimulus
     
@@ -80,6 +81,9 @@ def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'
     over time.  The first two dimensions of `stim_arr` together represent the
     exent of the visual display (pixels) and the last dimensions represents
     time (TRs).
+
+    The underlying function used here is `scipy.ndimage.zoom`. Some arguments
+    are passed through to that function.
     
     Parameters
     ----------
@@ -95,7 +99,12 @@ def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'
         Points outside the boundaries of the input are filled according
         to the given mode ('constant', 'nearest', 'reflect' or 'wrap').
         Default is 'nearest'.
-        
+
+    order : int, optional
+        Interpolation order, must be in range 0-5.
+
+    dtype : numpy dtype, optional
+        Datatype for the returned array.
         
     Returns
     -------
@@ -112,7 +121,7 @@ def resample_stimulus(stim_arr, scale_factor=0.05, mode='nearest', dtype='uint8'
     for tr in np.arange(dims[-1]):
         
         # resize it
-        f = zoom(stim_arr[:,:,tr], scale_factor, mode=mode)
+        f = zoom(stim_arr[:,:,tr], scale_factor, mode=mode, order=order)
         
         # insert it
         resampled_arr[:,:,tr] = f


### PR DESCRIPTION
I was having an issue where down-sampled stimuli looked "weird'. e.g.

```python
plt.imshow(stim[..., 10])
```
![image](https://cloud.githubusercontent.com/assets/315810/26170939/32fefcb0-3b11-11e7-8310-e9e955060039.png)


```python
stim_downsampled = resample_stimulus(stim, .2)
plt.imshow(stim_downsampled[..., 10])
```
![image](https://cloud.githubusercontent.com/assets/315810/26170913/1c961260-3b11-11e7-8f51-eac8690b6f3f.png)

The problem is that the default interpolation in `scipy.ndimage.zoom` is cubic spline, and so the combination of interpolation error and conversion back to int representation creates artifacts. (In principle. I have to admit I don't actually understand how spline interpolation artifacts end up looking like the example there).

This PR exposes the `order` parameter and allows the user to perform nearest neighbor interpolation.

There are some issues that should be thought about:

- The default interpolation order: I set it to 0 which matches, in my mind, the most common usecase where users will be passing a stimulus aperture image. But it is a change from the prior default (implicitly `order=3`)
- The order of keyword arguments. Personally I try to keep related kwargs together when adding new ones and thus stuck `order` before `dtype`. This will break code that used all parameters with positional arguments. Python 3 solves this problem with keyword-only arguments, but in the meantime, let me know if you want me to rearrange the parameters so `order` goes last.
- How to expose this parameter in the `VisualStimulus` class. That class has an `interp` parameter, but it's not clear to me whether it is actually [used anywhere](https://github.com/kdesimone/popeye/search?q=interp&type=Code&utf8=%E2%9C%93).

Also two issues occurred to me while interacting with this code:

- Should other `scipy.ndimage.zoom` parameters (i.e. `cval` and `prefilter`) be exposed? One option would be to catch `**kwargs` and pass them down.
- Should the default datatype in `resample_stimulus` use the dtype of the input array?