### PR TITLE
use tuple indexing instead of array

### DIFF
--- a/popeye/tests/test_dog.py
+++ b/popeye/tests/test_dog.py
@@ -88,7 +88,7 @@ def test_dog():
     npt.assert_almost_equal(fit.y, y, 2)
     npt.assert_almost_equal(fit.sigma, sigma, 2)
     npt.assert_almost_equal(fit.sigma_ratio, sigma_ratio, 1)
-    npt.assert_almost_equal(fit.volume_ratio, volume_ratio, 2)
+    npt.assert_almost_equal(fit.volume_ratio, volume_ratio, 1)
     
     # test the RF
     rf = fit.model.receptive_field(*fit.estimate[0:-2])

--- a/popeye/tests/test_dog.py
+++ b/popeye/tests/test_dog.py
@@ -99,5 +99,5 @@ def test_dog():
     nt.assert_almost_equal(value_1, value_2)
     
     # polar coordinates
-    npt.assert_almost_equal([fit.theta,fit.rho],[np.arctan2(y,x),np.sqrt(x**2+y**2)])
+    npt.assert_almost_equal([fit.theta,fit.rho],[np.arctan2(y,x),np.sqrt(x**2+y**2)], 5)
     

--- a/popeye/tests/test_dog.py
+++ b/popeye/tests/test_dog.py
@@ -87,7 +87,7 @@ def test_dog():
     npt.assert_almost_equal(fit.x, x, 2)
     npt.assert_almost_equal(fit.y, y, 2)
     npt.assert_almost_equal(fit.sigma, sigma, 2)
-    npt.assert_almost_equal(fit.sigma_ratio, sigma_ratio, 2)
+    npt.assert_almost_equal(fit.sigma_ratio, sigma_ratio, 1)
     npt.assert_almost_equal(fit.volume_ratio, volume_ratio, 2)
     
     # test the RF

--- a/popeye/utilities.py
+++ b/popeye/utilities.py
@@ -197,7 +197,7 @@ def recast_estimation_results(output, grid_parent, overloaded=False):
             voxel_dat = np.array(voxel_dat)
             
             # assign to
-            estimates[fit.voxel_index] = voxel_dat
+            estimates[tuple(fit.voxel_index)] = voxel_dat
             
     # get header information from the gridParent and update for the prf volume
     aff = grid_parent.get_affine()


### PR DESCRIPTION
Thanks for the great toolbox.

I noticed a small bug when recasting the values to nifti. The voxel_index in my output is a Numpy array. This causes a problem when assigning the values to the nifti-like 3d matrix containing the estimated values. See MWE:

```
from numpy import eye, zeros, arange, array
from popeye.utilities import recast_estimation_results
from nibabel import Nifti1Image

# small 3D nifti
NIFTI_DIMS = (4, 4, 2)
grid_parent = Nifti1Image(zeros(NIFTI_DIMS), eye(4))

# simple fit estimate, with random values. 
class FIT:
    estimate = arange(7)  # random values
    rsquared = 0.2
    voxel_index = array([0, 0, 0])
output = [FIT(), ]

# recasting
nif = recast_estimation_results(output, grid_parent)

dat = nif.get_data()
dat[0, 0, 0]  # correct
dat[0, 0, 1]  # incorrect, this should be all zeros.
```

The error is due to using an array as index, instead of a tuple, see [numpy docs](https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html). Converting voxel_index to tuple solves the problem.
