### PR TITLE
fixed mx+b orderings; many places in the code this was written as m(x+b)

### DIFF
--- a/popeye/auditory.py
+++ b/popeye/auditory.py
@@ -90,11 +90,11 @@ class AuditoryModel(PopulationModel):
         # regress out mean and amplitude
         beta, baseline = self.regress(model, self.data)
         
-        # offset
-        model += baseline
-        
         # scale
         model *= beta
+        
+        # offset
+        model += baseline
         
         return model
         
@@ -145,11 +145,11 @@ class AuditoryModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
         

--- a/popeye/auditory_hrf.py
+++ b/popeye/auditory_hrf.py
@@ -98,11 +98,11 @@ class AuditoryModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
     
@@ -156,11 +156,11 @@ class AuditoryModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
 

--- a/popeye/css.py
+++ b/popeye/css.py
@@ -76,11 +76,11 @@ class CompressiveSpatialSummationModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
         
@@ -112,11 +112,11 @@ class CompressiveSpatialSummationModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
         

--- a/popeye/dog.py
+++ b/popeye/dog.py
@@ -82,11 +82,11 @@ class DifferenceOfGaussiansModel(PopulationModel):
         # regress out mean and linear
         beta, baseline = self.regress(model, self.data)
         
-        # offset
-        model += baseline
-        
         # scale
         model *= beta
+        
+        # offset
+        model += baseline
         
         return model
         
@@ -119,11 +119,11 @@ class DifferenceOfGaussiansModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
             

--- a/popeye/og.py
+++ b/popeye/og.py
@@ -83,11 +83,11 @@ class GaussianModel(PopulationModel):
         # regress out mean and amplitude
         beta, baseline = self.regress(model, self.data)
         
-        # offset
-        model += baseline
-        
         # scale
         model *= beta
+        
+        # offset
+        model += baseline
         
         return model
         
@@ -136,11 +136,11 @@ class GaussianModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
     

--- a/popeye/og_hrf.py
+++ b/popeye/og_hrf.py
@@ -92,11 +92,11 @@ class GaussianModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
         
@@ -151,11 +151,11 @@ class GaussianModel(PopulationModel):
         if unscaled:
             return model
         else:
-            # offset
-            model += baseline
-    
             # scale it by beta
             model *= beta
+    
+            # offset
+            model += baseline
     
             return model
 

--- a/popeye/og_regularized_hrf.py
+++ b/popeye/og_regularized_hrf.py
@@ -83,11 +83,11 @@ class GaussianModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
         
@@ -127,11 +127,11 @@ class GaussianModel(PopulationModel):
         # units
         model = (model-np.mean(model)) / np.mean(model)
         
-        # offset
-        model += baseline
-        
         # scale it by beta
         model *= beta
+        
+        # offset
+        model += baseline
         
         return model
     

--- a/popeye/spatiotemporal.py
+++ b/popeye/spatiotemporal.py
@@ -93,11 +93,11 @@ class SpatioTemporalModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
     
@@ -157,11 +157,11 @@ class SpatioTemporalModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
     

--- a/popeye/spatiotemporal_2dcos.py
+++ b/popeye/spatiotemporal_2dcos.py
@@ -96,11 +96,11 @@ class SpatioTemporalModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
     
@@ -162,11 +162,11 @@ class SpatioTemporalModel(PopulationModel):
             return model
         else:
             
-            # offset
-            model += baseline
-            
             # scale it by beta
             model *= beta
+            
+            # offset
+            model += baseline
             
             return model
     

--- a/popeye/spatiotemporal_css.py
+++ b/popeye/spatiotemporal_css.py
@@ -83,11 +83,11 @@ class SpatioTemporalModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
         

--- a/popeye/spatiotemporal_hrf.py
+++ b/popeye/spatiotemporal_hrf.py
@@ -100,11 +100,11 @@ class SpatioTemporalModel(PopulationModel):
         # regress out mean and linear
         p = linregress(model, self.data)
         
-        # offset
-        model += p[1]
-        
         # scale
         model *= p[0]
+        
+        # offset
+        model += p[1]
         
         return model
     

--- a/popeye/tests/test_auditory.py
+++ b/popeye/tests/test_auditory.py
@@ -71,9 +71,12 @@ def test_auditory_fit():
     # grid fit
     npt.assert_almost_equal(fit.center_freq0, 3)
     npt.assert_almost_equal(fit.sigma0, 2.1553266676302263)
-    npt.assert_almost_equal(fit.beta0, 2.4528931326778265)
-    npt.assert_almost_equal(fit.baseline0, 1.416)
     npt.assert_almost_equal(fit.center_freq_hz, center_freq_hz)
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
+
     
     # final fit
     npt.assert_almost_equal(fit.center_freq, center_freq)

--- a/popeye/tests/test_auditory_hrf.py
+++ b/popeye/tests/test_auditory_hrf.py
@@ -73,10 +73,15 @@ def test_auditory_hrf_fit():
     
     # grid fit
     npt.assert_almost_equal(fit.center_freq0, 3)
-    npt.assert_almost_equal(fit.sigma0, 2)
     npt.assert_almost_equal(fit.hrf0, 1.2222222222222223)
-    npt.assert_almost_equal(fit.beta0, 2.3404365192849017)
-    npt.assert_almost_equal(fit.baseline0, 1.416)
+    # test the sigma parameter against best possibility
+    grid_sigmas = np.arange(s_grid.start, s_grid.stop, s_grid.step)
+    best_sigma = grid_sigmas[np.argmin(np.abs(grid_sigmas - sigma))]
+    npt.assert_array_less(np.abs(fit.sigma0 - sigma), s_grid.step)
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
     
     # final fit
     npt.assert_almost_equal(fit.center_freq, center_freq)

--- a/popeye/tests/test_dog.py
+++ b/popeye/tests/test_dog.py
@@ -77,12 +77,14 @@ def test_dog():
                 1.666666666666667,
                 2.8243187483428391,
                 1.9999999999999998,
-                0.10000000000000001,
-                0.3639449,
-                -0.025000000000000022]
+                0.10000000000000001]
                 
-    npt.assert_almost_equal((fit.x0,fit.y0,fit.s0,fit.sr0,fit.vr0, fit.beta0, fit.baseline0), ballpark)
-    
+    npt.assert_almost_equal((fit.x0,fit.y0,fit.s0,fit.sr0,fit.vr0), ballpark)
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
+
     # fine fit
     npt.assert_almost_equal(fit.x, x, 2)
     npt.assert_almost_equal(fit.y, y, 2)
@@ -99,5 +101,5 @@ def test_dog():
     nt.assert_almost_equal(value_1, value_2)
     
     # polar coordinates
-    npt.assert_almost_equal([fit.theta,fit.rho],[np.arctan2(y,x),np.sqrt(x**2+y**2)], 5)
+    npt.assert_almost_equal([fit.theta,fit.rho],[np.arctan2(y,x),np.sqrt(x**2+y**2)], 4)
     

--- a/popeye/tests/test_og.py
+++ b/popeye/tests/test_og.py
@@ -72,9 +72,13 @@ def test_og_fit():
     fit = og.GaussianFit(model, data, grids, bounds)
     
     # coarse fit
-    ballpark = [-5.       ,  5.       ,  2.75     ,  2.7656729, -0.625    ]
+    ballpark = [-5.       ,  5.       ,  2.75]
     
-    npt.assert_almost_equal((fit.x0, fit.y0, fit.s0, fit.beta0, fit.baseline0), ballpark)
+    npt.assert_almost_equal((fit.x0, fit.y0, fit.s0), ballpark)
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
     
     # assert equivalence
     npt.assert_almost_equal(fit.x, x)
@@ -150,9 +154,13 @@ def test_negative_og_fit():
     fit = og.GaussianFit(model, data, grids, bounds)
     
     # coarse fit
-    ballpark = [-5.0, 5.0, 2.75, -0.27940915461573274, -0.062499999999999993]
+    ballpark = [-5.0, 5.0, 2.75]
     
-    npt.assert_almost_equal((fit.x0, fit.y0, fit.s0, fit.beta0, fit.baseline0), ballpark)
+    npt.assert_almost_equal((fit.x0, fit.y0, fit.s0), ballpark)
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
     
     # assert equivalence
     npt.assert_almost_equal(fit.x, x, 2)

--- a/popeye/tests/test_og_hrf.py
+++ b/popeye/tests/test_og_hrf.py
@@ -78,10 +78,12 @@ def test_og_fit():
     npt.assert_almost_equal(fit.x0, -5.0)
     npt.assert_almost_equal(fit.y0, 5.0)
     npt.assert_almost_equal(fit.s0, 2.75)
-    npt.assert_almost_equal(fit.beta0, 2.7193885666278903)
-    npt.assert_almost_equal(fit.baseline0, -0.625)
     npt.assert_almost_equal(fit.hrf0, 0.5)
-    
+    # the baseline/beta should be 0/1 when regressed data vs. estimate
+    (m,b) = np.polyfit(fit.scaled_ballpark_prediction, data, 1)
+    npt.assert_almost_equal(m, 1.0)
+    npt.assert_almost_equal(b, 0.0)
+
     # assert equivalence
     npt.assert_almost_equal(fit.x, x)
     npt.assert_almost_equal(fit.y, y)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.11
+numpy>=1.11
 cython
 scipy
 matplotlib


### PR DESCRIPTION
In a few tests, I found that some simulated voxels were producing strangely bad fits in popeye; this badness went away when the data were whitened or mean-centered prior to being run through popeye. It ends up that throughout the code, there are places where model predictions are scaled and shifted incorrectly.

Typically, the issue goes like this:
* you use `(m,b) = linregress(something)` to get the scale and shift
* you add the shift: `model += b`
* then you scale: `model *= m`
The problem is that `linregress` returns `(m,b)` for the equation `y = m*x + b`; the formula being used in the code is `y = m*(x + b)`. If the shift (`b`) is significant, this tanks the rest of the fitting.

I **think** that I've fixed all of these in this pull request, but I possibly missed some. I am still learning this repo.

Cheers,
-Noah