### PR TITLE
fixed scaling of parameters in double gamma hrf

### DIFF
--- a/popeye/utilities.py
+++ b/popeye/utilities.py
@@ -615,10 +615,10 @@ def double_gamma_hrf(delay, tr, fptr=1.0, integrator=trapz):
     from scipy.special import gamma
     
     # add delay to the peak and undershoot params (alpha 1 and 2)
-    alpha_1 = 5/tr+delay/tr
+    alpha_1 = 5 + delay
     beta_1 = 1.0
     c = 0.1
-    alpha_2 = 15/tr+delay/tr
+    alpha_2 = 15 + delay
     beta_2 = 1.0
     
     t = np.arange(0,32,tr)


### PR DESCRIPTION
This fixes the issue outlined here: 
https://github.com/kdesimone/popeye/issues/63
