### PR TITLE
fixed unexpected float/int issue related to alpha parameters

### DIFF
--- a/popeye/utilities.py
+++ b/popeye/utilities.py
@@ -615,10 +615,10 @@ def double_gamma_hrf(delay, tr, fptr=1.0, integrator=trapz):
     from scipy.special import gamma
     
     # add delay to the peak and undershoot params (alpha 1 and 2)
-    alpha_1 = 5 + delay
+    alpha_1 = float(5 + delay)
     beta_1 = 1.0
     c = 0.1
-    alpha_2 = 15 + delay
+    alpha_2 = float(15 + delay)
     beta_2 = 1.0
     
     t = np.arange(0,32,tr)


### PR DESCRIPTION
It appears that my last commit created a separate issue when the delay is not a floating-point number. Previously, the fact that the parameters `alpha_1` and `alpha_2` were being divided by a number (even the integer 1) meant that they were converted to floats. When they are not converted, there is an artifact in the resulting time-series; this plot shows the correct value in red and the incorrect one in green: 

![image](https://user-images.githubusercontent.com/2005723/64436348-29681380-d092-11e9-963f-80cb018cf3d8.png)

This PR fixes this by forcing the alpha parameters to be floats.
